### PR TITLE
Fix file path loading errors by updating mod folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ local new_y = toilet_y + math.sin(angle) * radius
 ### 7. Installation Instructions
 
 1. Extract Noita's game data using modding tools
-2. Copy mod folder to `Noita/mods/toilet_flush_spell/`
+2. Copy mod folder to `Noita/mods/noita_toilet_flush/`
 3. Enable mod in Noita's mod menu
 4. Restart Noita
 5. Find "Toilet Flush" spell in spell pools or use console to spawn

--- a/data/gun_actions/gun_actions.lua
+++ b/data/gun_actions/gun_actions.lua
@@ -3,9 +3,9 @@ local actions = {
 		id          = "TOILET_FLUSH",
 		name 		= "$action_toilet_flush",
 		description = "$actiondesc_toilet_flush",
-		sprite 		= "mods/toilet_flush_spell/data/ui_gfx/gun_actions/toilet_flush.png",
-		sprite_unidentified = "mods/toilet_flush_spell/data/ui_gfx/gun_actions/toilet_flush_unidentified.png",
-		related_projectiles	= {"mods/toilet_flush_spell/files/entities/projectiles/toilet_flush.xml"},
+		sprite 		= "mods/noita_toilet_flush/data/ui_gfx/gun_actions/toilet_flush.png",
+		sprite_unidentified = "mods/noita_toilet_flush/data/ui_gfx/gun_actions/toilet_flush_unidentified.png",
+		related_projectiles	= {"mods/noita_toilet_flush/files/entities/projectiles/toilet_flush.xml"},
 		type 		= ACTION_TYPE_PROJECTILE,
 		spawn_level                       = "0,1,2,3,4,5,6",
 		spawn_probability                 = "0.1,0.2,0.3,0.4,0.5,0.6,0.7",
@@ -13,7 +13,7 @@ local actions = {
 		mana = 60,
 		max_uses = 15,
 		action 		= function()
-			add_projectile("mods/toilet_flush_spell/files/entities/projectiles/toilet_flush.xml")
+			add_projectile("mods/noita_toilet_flush/files/entities/projectiles/toilet_flush.xml")
 			c.fire_rate_wait = c.fire_rate_wait + 30
 			current_reload_time = current_reload_time + 30
 		end,

--- a/files/entities/projectiles/toilet_flush.xml
+++ b/files/entities/projectiles/toilet_flush.xml
@@ -38,7 +38,7 @@
 	</VelocityComponent>
 
 	<SpriteComponent 
-		image_file="mods/toilet_flush_spell/files/sprites/toilet.png"
+		image_file="mods/noita_toilet_flush/files/sprites/toilet.png"
 		offset_x="8"
 		offset_y="8"
 		alpha="1"
@@ -46,7 +46,7 @@
 	</SpriteComponent>
 
 	<LuaComponent
-		script_source_file="mods/toilet_flush_spell/files/scripts/toilet_spawn.lua"
+		script_source_file="mods/noita_toilet_flush/files/scripts/toilet_spawn.lua"
 		execute_every_n_frame="1"
 		execute_on_added="1"
 	>

--- a/files/entities/toilet_flush/toilet.xml
+++ b/files/entities/toilet_flush/toilet.xml
@@ -2,7 +2,7 @@
 <Entity name="toilet">
 
 	<SpriteComponent 
-		image_file="mods/toilet_flush_spell/files/sprites/toilet.png"
+		image_file="mods/noita_toilet_flush/files/sprites/toilet.png"
 		offset_x="16"
 		offset_y="16"
 		alpha="1"
@@ -23,7 +23,7 @@
 	<PhysicsImageShapeComponent 
 		body_id="1"
 		centered="1" 
-		image_file="mods/toilet_flush_spell/files/sprites/toilet.png"
+		image_file="mods/noita_toilet_flush/files/sprites/toilet.png"
 		material="meat"
 	>
 	</PhysicsImageShapeComponent>
@@ -41,14 +41,14 @@
 	</LifetimeComponent>
 
 	<LuaComponent
-		script_source_file="mods/toilet_flush_spell/files/scripts/toilet_interaction.lua"
+		script_source_file="mods/noita_toilet_flush/files/scripts/toilet_interaction.lua"
 		execute_every_n_frame="5"
 		execute_on_added="1"
 	>
 	</LuaComponent>
 
 	<LuaComponent
-		script_source_file="mods/toilet_flush_spell/files/scripts/toilet_effects.lua"
+		script_source_file="mods/noita_toilet_flush/files/scripts/toilet_effects.lua"
 		execute_every_n_frame="1"
 		execute_on_added="1"
 	>

--- a/files/scripts/toilet_effects.lua
+++ b/files/scripts/toilet_effects.lua
@@ -17,7 +17,7 @@ if not water_sound_played and effect_time > 30 then
 end
 
 if not flush_sound_played and effect_time > 180 then -- 3 seconds
-    GamePlaySound("mods/toilet_flush_spell/files/audio/toilet_flush.ogg", "", x, y)
+    GamePlaySound("mods/noita_toilet_flush/files/audio/toilet_flush.ogg", "", x, y)
     ComponentSetValue2(this_comp, "flush_sound_played", true)
     flush_sound_played = true
 end

--- a/files/scripts/toilet_interaction.lua
+++ b/files/scripts/toilet_interaction.lua
@@ -24,7 +24,7 @@ for i, enemy_id in ipairs(enemies) do
                 EntityInflictDamage(enemy_id, 25, "DAMAGE_CURSE", "Toilet flush clog", "NORMAL", 0, 0, entity_id)
                 
                 local swirl_comp = EntityAddComponent2(enemy_id, "LuaComponent", {
-                    script_source_file = "mods/toilet_flush_spell/files/scripts/toilet_swirl.lua",
+                    script_source_file = "mods/noita_toilet_flush/files/scripts/toilet_swirl.lua",
                     execute_every_n_frame = 1,
                     execute_on_added = 1
                 })
@@ -34,7 +34,7 @@ for i, enemy_id in ipairs(enemies) do
                 
             else
                 local swirl_comp = EntityAddComponent2(enemy_id, "LuaComponent", {
-                    script_source_file = "mods/toilet_flush_spell/files/scripts/toilet_swirl.lua",
+                    script_source_file = "mods/noita_toilet_flush/files/scripts/toilet_swirl.lua",
                     execute_every_n_frame = 1,
                     execute_on_added = 1
                 })

--- a/files/scripts/toilet_spawn.lua
+++ b/files/scripts/toilet_spawn.lua
@@ -4,7 +4,7 @@ function shot()
 	local entity_id = GetUpdatedEntityID()
 	local x, y = EntityGetTransform(entity_id)
 	
-	local toilet_entity = EntityLoad("mods/toilet_flush_spell/files/entities/toilet_flush/toilet.xml", x, y)
+	local toilet_entity = EntityLoad("mods/noita_toilet_flush/files/entities/toilet_flush/toilet.xml", x, y)
 	
 	EntityKill(entity_id)
 end

--- a/init.lua
+++ b/init.lua
@@ -6,7 +6,7 @@ end
 
 function OnModInit()
 	print("Toilet Flush Spell mod: Init")
-	ModLuaFileAppend("data/scripts/gun/gun_actions.lua", "mods/toilet_flush_spell/data/gun_actions/gun_actions.lua")
+	ModLuaFileAppend("data/scripts/gun/gun_actions.lua", "mods/noita_toilet_flush/data/gun_actions/gun_actions.lua")
 end
 
 function OnModPostInit()


### PR DESCRIPTION
- Update init.lua ModLuaFileAppend path from 'toilet_flush_spell' to 'noita_toilet_flush'
- Fix all sprite and script references in XML files to use correct mod folder name
- Update gun_actions.lua sprite paths to match actual folder structure
- Update README.md installation instructions with correct folder name
- Resolves 'Error loading lua script - file doesn't exist' messages in Noita

All mod file paths now correctly reference 'noita_toilet_flush' folder name