### PR TITLE
Fix actions_to_add nil error in gun_actions.lua

### DIFF
--- a/data/gun_actions/gun_actions.lua
+++ b/data/gun_actions/gun_actions.lua
@@ -20,6 +20,8 @@ local actions = {
 	},
 }
 
-for i,v in ipairs(actions) do
-	table.insert(actions_to_add, v)
+if actions_to_add ~= nil then
+	for i,v in ipairs(actions) do
+		table.insert(actions_to_add, v)
+	end
 end


### PR DESCRIPTION
- Add safety check to ensure actions_to_add table exists before inserting
- Prevents 'bad argument #1 to insert (table expected, got nil)' error
- Resolves mod loading issues when actions_to_add is not yet initialized

This fixes the Lua error that was preventing the toilet flush spell from loading properly.